### PR TITLE
Provide an example of how to handle custom build phase scripts 

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -59,9 +59,20 @@ let project = Project(name: "SampleProject",
                                             "/Users/ghaithalnajjar/Downloads/SampleProject/iOSApp/CountryWiki/Modules/Countries/Models/CountriesProvider+CountriesProviderProtocol.swift",
                                             
                                       ],
+                                  scripts: [
+                                    .post(
+                                      script: """
+                                              . ../BuildTools/swiftlint.sh
+                                              swiftlintWrapped ../BuildTools/
+                                              """,
+                                      name: "Swiftlint",
+                                      basedOnDependencyAnalysis: true,
+                                      shellPath: "/bin/zsh"
+                                    )
+                                  ],
                                   dependencies: [
-                                   // .package(url: "https://github.com/realm/SwiftLint.git", from: "0.51.0-rc.2")
-                                             ]
+                                    // .package(url: "https://github.com/realm/SwiftLint.git", from: "0.51.0-rc.2")
+                                  ]
                                   
                                      /* preActions: [
                                                       TargetAction.tool(


### PR DESCRIPTION
This change will give you an idea of how to handle the SwiftLint / SwiftFormat build phases of the original SampleProject.

What you were trying to do is specifying SwiftLint as an actual dependency on the project and somehow invoking it inside the Tuist project file.
However, the initial SampleProject has no hard dependency on SwiftLint (or SwiftFormat for that matter). Instead, it just runs a script that checks if the tool is installed and if it is, it will invoke the tool with the right config.

So what you should be doing, is simply mimicking the existing SwiftLint & SwiftFormat BuildPhases of the original SampleProject by specifying them as scripts in the Tuist project file.

I provided an example that mimics the SwiftLint build phase, it should be easy to do the same for the SwiftFormat build phase too. 